### PR TITLE
Made function name consistent in PSE 4.

### DIFF
--- a/04/implement-palindrome.checkpoint.md
+++ b/04/implement-palindrome.checkpoint.md
@@ -11,7 +11,7 @@
 
 Imagine working on software that processes text. A palindrome is a word, phrase, or sequence that reads the same backward as forward.
 
-Create a function named `is_palindrome` that determines if a string is a palindrome. This method should take in one string as a parameter. This method should return `True` if the string is a palindrome.
+Create a function named `palindrome` that determines if a string is a palindrome. This method should take in one string as a parameter. This method should return `True` if the string is a palindrome.
 
 ## Examples
 

--- a/04/palindrome.md
+++ b/04/palindrome.md
@@ -4,7 +4,7 @@
 
 Imagine working on software that processes text. A palindrome is a word, phrase, or sequence that reads the same backward as forward.
 
-Create a function named `is_palindrome` that determines if a string is a palindrome. This method should take in one string as a parameter. This method should return `True` if the string is a palindrome.
+Create a function named `palindrome` that determines if a string is a palindrome. This method should take in one string as a parameter. This method should return `True` if the string is a palindrome.
 
 ### Examples
 


### PR DESCRIPTION
- Made it so all references to the function say `palindrome` instead of `is_palindrome`.