### PR TITLE
Expand PSE1 Tests

### DIFF
--- a/01/implement-highest-rated.checkpoint.md
+++ b/01/implement-highest-rated.checkpoint.md
@@ -38,13 +38,32 @@ from main import *
 
 class TestChallenge(unittest.TestCase):
     def test_picks_highest_rated_from_list(self):
-        restaurants = [{"name": "Grillby's", "rating": 1},
+        restaurants1 = [{"name": "Grillby's", "rating": 1},
                        {"name": "Crow's Nest", "rating": 5}]
 
-        output = get_highest_rated(restaurants)
-        self.assertEqual(output["name"], "Crow's Nest")
-        self.assertEqual(output["rating"], 5)
-        self.assertEqual(len(output.keys()), 2)
+        restaurants2 = [{"name": "Communion", "rating": 5},
+                       {"name": "Fat's Chicken", "rating": 4}]
+
+        restaurants3 = [{"name": "A guy on the street giving away granola bars", "rating": 1},
+                       {"name": "Soul", "rating": 4},
+                       {"name": "Dick's", "rating": 2}]
+
+        output1 = get_highest_rated(restaurants1)
+        output2 = get_highest_rated(restaurants2)
+        output3 = get_highest_rated(restaurants3)
+        # 
+        self.assertEqual(output1["name"], "Crow's Nest")
+        self.assertEqual(output1["rating"], 5)
+        self.assertEqual(len(output1.keys()), 2)
+
+        self.assertEqual(output2["name"], "Communion")
+        self.assertEqual(output2["rating"], 5)
+        self.assertEqual(len(output2.keys()), 2)
+
+        self.assertEqual(output3["name"], "Soul")
+        self.assertEqual(output3["rating"], 4)
+        self.assertEqual(len(output3.keys()), 2)
+
 
     def test_picks_from_list_of_one(self):
         restaurants = [{"name": "Crow's Nest", "rating": 1}]

--- a/01/implement-highest-rated.checkpoint.md
+++ b/01/implement-highest-rated.checkpoint.md
@@ -51,7 +51,7 @@ class TestChallenge(unittest.TestCase):
         output1 = get_highest_rated(restaurants1)
         output2 = get_highest_rated(restaurants2)
         output3 = get_highest_rated(restaurants3)
-        # 
+         
         self.assertEqual(output1["name"], "Crow's Nest")
         self.assertEqual(output1["rating"], 5)
         self.assertEqual(len(output1.keys()), 2)


### PR DESCRIPTION
Fix: Tests are passing as long as you return the last value of the restaurant list.

Added 2 more restaurant lists to test:
1. First new list has highest rated as first item in list
2. Second new list has highest rated as 2nd item in list of length 3