### PR TITLE
Updates to example PSE for C26

### DIFF
--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -156,7 +156,7 @@ Even if we make a decision about how to handle a particular issue here, the unit
 2. Write unit tests for `winner` for the nominal and edge cases you identified in the first step.
     
 When naming a test, we want to ensure the name describes the scenario we are testing by including information like the function being tested, inputs, and expected outputs. 
-* This may not seem useful here where we are only writing two tests, but building strong naming habits now will helps us once we're in production environments where a single function or component may have dozens of tests that we need to be able to quickly distinguish from each other.
+* This may not seem useful here where we are only writing two tests, but building strong naming habits now will benefit us once we're in production environments where a single function or component may have dozens of tests that we need to be able to quickly distinguish from each other.
 
 *Note: Click the **Run Tests** button to save your tests for instructor feedback. No real tests are actually run again your unit tests.*
 ##### !end-question

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -58,13 +58,13 @@ As you come up with observations and questions, assume that error handling for i
 ##### !end-question
 ##### !placeholder
 
-Add observations, assuptions, and questions here:
+Add observations, assumptions, and questions here:
 
 1. From the problem description, I observe that...
-2. From the example inputs I can see...
+2. In the example inputs I can see...
 3. A question I have around inputs is...
-4. ...
-5. ...
+4. Based on the requirements, I am making the assumption...
+5. What behavior is expected when...
 
 ##### !end-placeholder
 ##### !hint
@@ -156,6 +156,8 @@ Even if we make a decision about how to handle a particular issue here, the unit
 2. Write unit tests for `winner` for the nominal and edge cases you identified in the first step.
     
 When naming a test, we want to ensure the name describes the scenario we are testing by including information like the function being tested, inputs, and expected outputs. 
+
+For example, if we wanted to test that the function `winner` returns a tie when `player_1` and `player_2` have the same value, then we might name the test something like `test_winner_returns_tie_for_players_with_same_value`.
 * This may not seem useful here where we are only writing two tests, but building strong naming habits now will benefit us once we're in production environments where a single function or component may have dozens of tests that we need to be able to quickly distinguish from each other.
 
 *Note: Click the **Run Tests** button to save your tests for instructor feedback. No real tests are actually run again your unit tests.*

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -343,7 +343,9 @@ In the box below, please submit:
 ##### !end-question
 ##### !explanation
 
-As an example, let’s say we used the sample response from the "Logical Steps" question above to fill in the prompt template. Depending on exactly what ChatGPT shares, a reflection and summary might look like:
+As an example, let’s say we used a slightly modified version of the sample response from the "Logical Steps" question above to fill in the prompt template. In this example, the only change is that we refer to checking for a tie as an "edge case" in the first step.
+
+Depending on exactly what ChatGPT shares, a reflection and summary might look like:
 
 <br>
 

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -373,7 +373,7 @@ Around irrelevant feedback, the AI flagged that I was implicitly assuming valid 
 
 <br>
 
-Finally, I was genuinely surprised by the reframe around why to handle the tie first. I thought I was identifying it as a special case, but the feedback reframed it as a deliberate structural choice that simplifies the logic below it. That shift from "this is different" to "this makes everything else cleaner" changes how I'll think about ordering conditions in future problems too.
+Finally, I was genuinely surprised by the reframe around why to handle the tie first. I thought I was identifying it as a special case, but the feedback reframed it as a deliberate structural choice that simplifies the logic below it. That shift from "this is different" to "this makes everything else cleaner" changes how I'll think about ordering conditions in future problems.
 
 ##### !end-explanation
 ### !end-challenge

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -56,6 +56,17 @@ As you come up with observations and questions, assume that error handling for i
 - String Sanitization: You may assume strings will not include invalid characters.
 
 ##### !end-question
+##### !placeholder
+
+Add observations, assuptions, and questions here:
+
+1. From the problem description, I observe that...
+2. From the example inputs I can see...
+3. A question I have around inputs is...
+4. ...
+5. ...
+
+##### !end-placeholder
 ##### !hint
 
 Further questions to ask as you read through the problem statement and examples:
@@ -131,92 +142,6 @@ Even if we make a decision about how to handle a particular issue here, the unit
 
 <!-- prettier-ignore-start -->
 ### !challenge
-* type: paragraph
-* id: d14c0645-1681-4874-ba8c-37e1bb19262d
-* title: Review Observations & Questions
-* topics: pse
-##### !question
-
-While we build our skills in breaking down a problem and choosing clarifying questions, let’s use an external tool like ChatGPT to review the observations and questions we wrote while describing our understanding. 
-
-<br>
-
-Our goals are to: 
-- confirm if our observations and assumptions make sense in the context of the code problem
-- ensure we are asking questions that will tell us new information about the problem space
-- check our understanding of the information we expect to get from those questions
-- uncover other observations that would help shape our approach and understand how they would affect our approach
-- uncover further questions that could be useful to ask and understand why those other questions could be helpful
-
-<br>
-
-For this question we will:
-1. Build a prompt using [the template linked here](https://gist.githubusercontent.com/ada-instructors/16c97dc4b16ab2bf449d9d7a81caeb16/raw/pse_observations_questions_review_template.md)
-2. Share the completed prompt with an AI tool like ChatGPT
-3. After the initial review, ask the AI tool *at least one* follow up question that furthers your understanding of the problem and why certain observations or questions are useful. Some examples could be asking questions to: 
-    - ensure your understanding of the analysis of the observations
-    - get more details on the information we could get from asking particular questions
-    - learn more about new information shared by the tool
-4. Reflect on the information shared by the AI tool and summarize its findings and your learnings
-
-<br>
-
-In the box below, please submit:
-1. A shareable link to your conversation in ChatGPT
-    - [Documentation for creating a shareable link in ChatGPT](https://help.openai.com/en/articles/7925741-chatgpt-shared-links-faq)
-2. Your reflections and summary of the discussion with ChatGPT
-
-##### !end-question
-##### !hint
-
-**Troubleshooting**
-- If you are having issues with the tool understanding the prompt, try formatting the problem statement or examples differently.
-- If you’ve reformatted the information and are still not getting useful results, reach out in #study-hall and share what you are experiencing and the link to your chat so folks can take a look and help you troubleshoot!
-
-<br>
-
-**Summarizing the Review**
-- Did the AI tool uncover anything about the observations you made that you hadn’t considered?
-- Did the AI tool uncover anything about the questions you asked that you hadn’t considered?
-- Did the AI tool suggest updates to the observations you made or questions you asked? 
-    - If so, what updates and why?
-- Did the AI tool suggest any new observations or questions?
-    - If so, what? Why would they be useful?
-
-##### !end-hint
-##### !explanation 
-
-Everyone’s observations, questions, and following conversation with ChatGPT will be a little different, thus, the summaries will look a little different. For this example, we'll use the questions and explanations from the "Explanation" section of the previous question as examples to create our prompt. 
-- After you submit a response in Learn, you'll see "Show Explanation" appear. When it is clicked a section will expand to reveal an explanation. If you have not yet, try it out above to see the data we're working with!
-
-<br>
-
-Depending on exactly what ChatGPT shares, a reflection and summary might look like:
-
-<br>
-
-*Note:*
-
-*We are using a gist link in this example to ensure that the link exists from cohort to cohort. When submitting your response, the link should be a shareable link to your chat in the AI tool where you held the conversation.*
-
-<br>
-
-Chat link: [https://gist.github.com/ada-instructors/8d1dd2bcb00e3ce86ca061c5f2509c14](https://gist.github.com/ada-instructors/8d1dd2bcb00e3ce86ca061c5f2509c14) 
-
-<br>
-
-I received positive feedback that my observations about the coding problem were clear, accurate, and well-supported by the examples and rules provided, such as my reasoning about how the rules work (like same move = tie and player position matters). I didn't list any clarifying questions, so I got suggestions for some around whether the inputs are guaranteed to be lowercase or always valid. These questions help reveal if I need to handle errors or normalize data, even though those aspects are outside the scope of the PSE. 
-
-<br>
-
-One helpful insight was that there are only nine possible input combinations, making it easy to fully test the function. This makes testing straightforward because the entire input space is small, finite, and fully specified. The feedback encouraged me to keep cross-checking examples with logic and to ask clarifying questions early.
-
-##### !end-explanation
-### !end-challenge
-<!-- prettier-ignore-end -->
-
-<!-- prettier-ignore-start -->
-### !challenge
 * type: code-snippet
 * language: python3.6
 * id: f4a31dc6-158a-4050-8a11-fead5fef0040
@@ -229,6 +154,9 @@ One helpful insight was that there are only nine possible input combinations, ma
     * What is the expected output for the given input?
     * You can use the examples provided in the prompt, or other examples.
 2. Write unit tests for `winner` for the nominal and edge cases you identified in the first step.
+    
+When naming a test, we want to ensure the name describes the scenario we are testing by including information like the function being tested, inputs, and expected outputs. 
+* This may not seem useful here where we are only writing two tests, but building strong naming habits now will helps us once we're in production environments where a single function or component may have dozens of tests that we need to be able to quickly distinguish from each other.
 
 *Note: Click the **Run Tests** button to save your tests for instructor feedback. No real tests are actually run again your unit tests.*
 ##### !end-question
@@ -321,9 +249,9 @@ def test_winner_both_rock_results_in_tie():
 * topics: pse
 ##### !question
 
-Without writing code, describe how you would implement `winner` in enough detail that another developer could reasonably implement a solution. We should capture the main use cases, but the steps do not need to be a detailed plan for every contingency. 
-- The objective is to create a roadmap that we can use to keep ourselves oriented towards our goal
-- It is okay to leave some of the finer details to be worked out in the implementation itself!
+Without writing code, describe how you would implement `winner` as if you were talking through the details with another developer who will have to implement the function. We should capture the main use cases, but the steps do not need to be a detailed plan for every contingency. 
+* The objective is to practice describing algorithms and technical concepts while creating a roadmap that we can use to keep ourselves oriented towards our goal during the implementation step.
+* It is okay to leave some of the finer details to be worked out in the implementation itself!
 
 As you write your steps, keep the following guidelines in mind:
 * We want to think about a general approach rather than what the code would look like line-by-line. 
@@ -332,7 +260,7 @@ As you write your steps, keep the following guidelines in mind:
 * The steps should be a description as if you were talking out the problem with another person and should be agnostic of any particular language. 
     * As such, they should not include code syntax in the description.
 
-What's important at this stage is to think through and outline the implementation before writing code.
+What's important at this stage is to think through how you would put an approach into words, and outline the implementation before writing code.
 
 ##### !end-question
 ##### !placeholder
@@ -355,17 +283,17 @@ During an interview, we'd still want to be careful not to spend _too_ much time 
 <br>
 
 Example steps:
-1. Check for a tie: 
-    - if player_1 is the same as player_2, return "It's a tie!"
-2. First deal with the case that player_1 is "rock"
+1. First, we want to handle our edge case by checking for a tie: 
+    - if `player_1` is the same as `player_2`, return "It's a tie!"
+2. If it is not a tie, we'll move through the cases where `player_1` is "rock", "paper", or "scissors" to determine a winner, starting with the case that player_1 is "rock":
     - if player_2 is "scissors", return "Player 1 wins!"
     - otherwise player_2 must be "paper", return "Player 2 wins!"
-3. Next deal with the case that player_1 is "paper"
+3. Next we'll deal with the case that player_1 is "paper":
     - if player_2 is "rock", return "Player 1 wins!"
     - otherwise player_2 must be "scissors", return "Player 2 wins!"
-4. Otherwise player_1 must be "scissors"
+4. Otherwise player_1 must be "scissors":
     - if player_2 is "rock", return "Player 2 wins!"
-    - otherwise player_2 must be "paper", return "Player 1 wins!"
+    - otherwise player_2 must be "paper", return "Player 1 wins!" 
 
 ##### !end-explanation
 ### !end-challenge
@@ -379,22 +307,31 @@ Example steps:
 * topics: pse
 ##### !question
 
-We want to know if we are laying out an approach to the coding problem that makes sense for our context and if that approach is clearly conveying our thoughts on technical topics to others. Let’s once more use an AI tool like ChatGPT, this time to review the Logical Steps we wrote above. Our goals are to check if:
-- the steps make sense for the problem being solved
-- the steps are not missing important steps or scenarios
-- the steps are agnostic of any particular language – steps should not include code syntax.
-- the steps are written with enough detail for another developer to understand how to create a solution
+We want to know if we are laying out an approach to the coding problem that makes sense for our context and if that approach is clearly conveying our thoughts on technical topics to others. While we build our skills in breaking down and describing algorithms, let’s use an AI tool like ChatGPT to review the Logical Steps we wrote above. Our goals are to check if the steps:
+- convey the technical concepts and requirements of the problem in a way that another person can understand
+- make sense for the problem being solved
+- are not missing important steps or scenarios
+- are agnostic of any particular language – the steps should not include code syntax.
 
 <br>
 
 For this question we will:
 1. Build a prompt using [the template linked here](https://gist.githubusercontent.com/ada-instructors/670252696f1625cf0ed77c0997cd165d/raw/pse_logical_steps_review_template.md)
 2. Share the completed prompt with an AI tool like ChatGPT
-3. After the initial review, ask *at least one* follow up question using the AI tool. We want to ask questions that help us understand: 
-    - areas where we could add clarity
-    - edge cases we might have missed
-    - places where our steps do not meet the expectations of the problem statement
-4. Reflect on the information shared by the AI tool and summarize its findings and your learnings
+3. Reflect on the information shared by the AI tool, then use the prompts below to summarize its findings and your learnings.
+
+<br>
+
+Reflection Prompts
+
+1. Identify one specific strength the AI highlighted in your explanation. 
+    * Quote or paraphrase the part of the feedback that mentions this strength, and explain why you think that aspect of your explanation was effective.
+2. Point out at least one specific improvement the AI recommended.
+    * Describe exactly which part of your explanation would benefit from strengthening then outline how you would revise that part if you were rewriting it now.
+3. Identify one piece of AI feedback you believe was inaccurate, irrelevant, or unnecessary. 
+    * Explain why it doesn’t apply to this problem, and cite a source (docs, class notes, instructor explanation, or trusted online reference) that supports your reasoning.
+4. Describe one change the AI suggested that was new or surprised you. 
+    * Share how this suggestion shifted your understanding of the problem or your explanation.
 
 <br>
 
@@ -420,15 +357,13 @@ Chat Link: [https://gist.github.com/ada-instructors/56c872acec770c68a9ae8b81b58a
 
 <br>
 
-I received feedback that my approach was clear, and my logical steps that didn’t rely on Python specific syntax, which made it easy to understand. I made good use of logic by handling ties first and explaining each outcome clearly, showing I understood the reasoning behind the rules. 
+One strength the AI highlighted was my use of "otherwise... must be" phrasing throughout my steps. The feedback noted that this showed I understood "that earlier conditions have already eliminated other possibilities," which is the kind of reasoning interviewers want to see. I think this worked well because it demonstrates I wasn't just listing cases mechanically, I was actively narrowing down what remained, which makes the logic easier to follow and verify.
 
-<br>
+The main improvement the AI recommended was dropping the term "edge case" when describing the tie condition. My explanation currently calls it an edge case to justify handling it first, but the feedback pointed out that a tie isn't unusual, it occurs roughly a third of the time. If I were rewriting that step, I'd say something like "we check for a tie first because it's the simplest condition to eliminate, and removing it upfront reduces the branching we need below." 
 
-An area mentioned for improvement is to keep my language more consistent in how I describe outcomes and reasoning. For example, I could phrase outcomes in a way that explains why a player wins, not just that they win. Another suggestion was to consider alternative ways of structuring the logic, like grouping by winning relationships (e.g., “rock beats scissors”). This structure shows I grasp the underlying game logic, not just how to implement it procedurally. 
+Around irrelevant feedback, the AI flagged that I was implicitly assuming valid input and suggested I acknowledge that assumption explicitly. I'd push back on this suggestion for this problem since the problem statement itself defines the inputs as exactly "rock", "paper", or "scissors", so there's no ambiguity to address. According to how my instructor has framed problem-solving exercises, we're expected to work within the constraints given, not expand scope by handling cases the problem rules out. Calling that a gap feels like feedback written for a different, more open-ended problem. 
 
-<br>
-
-Overall, I’m on the right track, and with small tweaks to my phrasing and logic organization, I can make my solutions even stronger and more flexible.
+Finally, I was genuinely surprised by the reframe around why to handle the tie first. I thought I was identifying it as a special case, but the feedback reframed it as a deliberate structural choice that simplifies the logic below it. That shift from "this is different" to "this makes everything else cleaner" changes how I'll think about ordering conditions in future problems too.
 
 ##### !end-explanation
 ### !end-challenge

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -354,12 +354,17 @@ Depending on exactly what ChatGPT shares, a reflection and summary might look li
 <br>
 
 *Note:*
-
-*We are using a gist link in this example to ensure that the link exists from cohort to cohort. When submitting your response, the link should be a shareable link to your chat in the AI tool where you held the conversation.*
+Depending on exactly what the AI shares, a reflection and summary might look like:
 
 <br>
 
 Chat Link: [https://gist.github.com/ada-instructors/56c872acec770c68a9ae8b81b58a80a1](https://gist.github.com/ada-instructors/56c872acec770c68a9ae8b81b58a80a1)
+
+<br>
+
+*Note:*
+
+*We are using a gist link in this example to ensure that the link exists from cohort to cohort. When submitting your response, the link should be a shareable link to your chat in the AI tool where you held the conversation.*
 
 <br>
 

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -283,7 +283,7 @@ During an interview, we'd still want to be careful not to spend _too_ much time 
 <br>
 
 Example steps:
-1. First, we want to handle our edge case by checking for a tie: 
+1. First, we'll handle our simplest case which is checking for a tie: 
     - if `player_1` is the same as `player_2`, return "It's a tie!"
 2. If it is not a tie, we'll move through the cases where `player_1` is "rock", "paper", or "scissors" to determine a winner, starting with the case that player_1 is "rock":
     - if player_2 is "scissors", return "Player 1 wins!"

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -156,8 +156,7 @@ Even if we make a decision about how to handle a particular issue here, the unit
 2. Write unit tests for `winner` for the nominal and edge cases you identified in the first step.
     
 When naming a test, we want to ensure the name describes the scenario we are testing by including information like the function being tested, inputs, and expected outputs. 
-
-For example, if we wanted to test that the function `winner` returns a tie when `player_1` and `player_2` have the same value, then we might name the test something like `test_winner_returns_tie_for_players_with_same_value`.
+* For example, if we wanted to test that the function `winner` returns a tie when `player_1` and `player_2` have the same value, then we might name the test something like `test_winner_both_inputs_paper_returns_tie`.
 * This may not seem useful here where we are only writing two tests, but building strong naming habits now will benefit us once we're in production environments where a single function or component may have dozens of tests that we need to be able to quickly distinguish from each other.
 
 *Note: Click the **Run Tests** button to save your tests for instructor feedback. No real tests are actually run again your unit tests.*
@@ -287,15 +286,15 @@ During an interview, we'd still want to be careful not to spend _too_ much time 
 Example steps:
 1. First, we'll handle our simplest case which is checking for a tie: 
     - if `player_1` is the same as `player_2`, return "It's a tie!"
-2. If it is not a tie, we'll move through the cases where `player_1` is "rock", "paper", or "scissors" to determine a winner, starting with the case that player_1 is "rock":
-    - if player_2 is "scissors", return "Player 1 wins!"
-    - otherwise player_2 must be "paper", return "Player 2 wins!"
-3. Next we'll deal with the case that player_1 is "paper":
-    - if player_2 is "rock", return "Player 1 wins!"
-    - otherwise player_2 must be "scissors", return "Player 2 wins!"
-4. Otherwise player_1 must be "scissors":
-    - if player_2 is "rock", return "Player 2 wins!"
-    - otherwise player_2 must be "paper", return "Player 1 wins!" 
+2. If it is not a tie, we'll move through the cases where `player_1` is "rock", "paper", or "scissors" to determine a winner, starting with the case that `player_1` is "rock":
+    - if `player_2` is "scissors", return "Player 1 wins!"
+    - otherwise `player_2` must be "paper", return "Player 2 wins!"
+3. Next we'll deal with the case that `player_1` is "paper":
+    - if `player_2` is "rock", return "Player 1 wins!"
+    - otherwise `player_2` must be "scissors", return "Player 2 wins!"
+4. Otherwise `player_1` must be "scissors":
+    - if `player_2` is "rock", return "Player 2 wins!"
+    - otherwise `player_2` must be "paper", return "Player 1 wins!" 
 
 ##### !end-explanation
 ### !end-challenge

--- a/about-pses/example-pse.md
+++ b/about-pses/example-pse.md
@@ -345,6 +345,8 @@ In the box below, please submit:
 
 As an example, let’s say we used a slightly modified version of the sample response from the "Logical Steps" question above to fill in the prompt template. In this example, the only change is that we refer to checking for a tie as an "edge case" in the first step.
 
+<br>
+
 Depending on exactly what ChatGPT shares, a reflection and summary might look like:
 
 <br>
@@ -361,9 +363,15 @@ Chat Link: [https://gist.github.com/ada-instructors/56c872acec770c68a9ae8b81b58a
 
 One strength the AI highlighted was my use of "otherwise... must be" phrasing throughout my steps. The feedback noted that this showed I understood "that earlier conditions have already eliminated other possibilities," which is the kind of reasoning interviewers want to see. I think this worked well because it demonstrates I wasn't just listing cases mechanically, I was actively narrowing down what remained, which makes the logic easier to follow and verify.
 
+<br>
+
 The main improvement the AI recommended was dropping the term "edge case" when describing the tie condition. My explanation currently calls it an edge case to justify handling it first, but the feedback pointed out that a tie isn't unusual, it occurs roughly a third of the time. If I were rewriting that step, I'd say something like "we check for a tie first because it's the simplest condition to eliminate, and removing it upfront reduces the branching we need below." 
 
-Around irrelevant feedback, the AI flagged that I was implicitly assuming valid input and suggested I acknowledge that assumption explicitly. I'd push back on this suggestion for this problem since the problem statement itself defines the inputs as exactly "rock", "paper", or "scissors", so there's no ambiguity to address. According to how my instructor has framed problem-solving exercises, we're expected to work within the constraints given, not expand scope by handling cases the problem rules out. Calling that a gap feels like feedback written for a different, more open-ended problem. 
+<br>
+
+Around irrelevant feedback, the AI flagged that I was implicitly assuming valid input and suggested I acknowledge that assumption explicitly. I'd push back on this suggestion for this problem since the problem statement itself defines the inputs as exactly "rock", "paper", or "scissors", so there's no ambiguity to address. According to how my instructors have framed problem-solving exercises, we're expected to work within the constraints given, not expand scope by handling cases the problem rules out. Calling that a gap feels like feedback written for a different, more open-ended problem. 
+
+<br>
 
 Finally, I was genuinely surprised by the reframe around why to handle the tie first. I thought I was identifying it as a special case, but the feedback reframed it as a deliberate structural choice that simplifies the logic below it. That shift from "this is different" to "this makes everything else cleaner" changes how I'll think about ordering conditions in future problems too.
 


### PR DESCRIPTION
# Tickets
- [Example PSE Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1215168137850940?focus=true)
- [Parent Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1212367525684514?focus=true)

# Related Gist Review
Since we updated the logical step review template, I needed to update the example conversation we link to in the explanation section. Since gists don't support PRs, the new version is in a secret gist [here for review](https://gist.github.com/ada-instructors/997ce79959113865bb4df077ff50d400) and the old version is [here](https://gist.github.com/ada-instructors/56c872acec770c68a9ae8b81b58a80a1) for comparison.
- Once reviewed/any updates made to the temp gist, I'll copy the contents over to the original gist and delete the temp so we don't need to update the link in the lesson.

# Ask for Feedback
- We wanted to start including placeholders for the Questions & Observations section using examples from the example PSE on future PSEs. For this one, I didn't know if we also wanted some kind of placeholder, so I added something, would love feedback if folks think that's useful or have suggestions for improvements.
- I also added a sentence about test naming to the writing tests step and would love to hear if folks think that's helpful or should be removed.